### PR TITLE
Add Java based websocket server

### DIFF
--- a/ChatServer.java
+++ b/ChatServer.java
@@ -1,0 +1,86 @@
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpExchange;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+
+public class ChatServer extends WebSocketServer {
+    private final Set<WebSocket> connections = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    public ChatServer(int port) {
+        super(new InetSocketAddress(port));
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        connections.add(conn);
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        connections.remove(conn);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        for (WebSocket socket : connections) {
+            socket.send(message);
+        }
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        ex.printStackTrace();
+    }
+
+    @Override
+    public void onStart() {
+        System.out.println("WebSocket server started on port " + getPort());
+    }
+
+    public static void main(String[] args) throws IOException {
+        int httpPort = 8080;
+        int wsPort = 8081;
+        ChatServer server = new ChatServer(wsPort);
+        server.start();
+        startHttp(httpPort);
+        System.out.println("HTTP server started on port " + httpPort);
+    }
+
+    private static void startHttp(int port) throws IOException {
+        HttpServer http = HttpServer.create(new InetSocketAddress(port), 0);
+        http.createContext("/", ChatServer::handleStatic);
+        http.setExecutor(null);
+        http.start();
+    }
+
+    private static void handleStatic(HttpExchange exchange) throws IOException {
+        String uri = exchange.getRequestURI().getPath();
+        if (uri.equals("/")) {
+            uri = "/index.html";
+        }
+        Path file = Paths.get("public", uri.substring(1));
+        if (!Files.exists(file)) {
+            exchange.sendResponseHeaders(404, -1);
+            return;
+        }
+        String type = Files.probeContentType(file);
+        byte[] bytes = Files.readAllBytes(file);
+        if (type != null) {
+            exchange.getResponseHeaders().add("Content-Type", type);
+        }
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# gptcode
+# Anonymous WebSocket Chat
+
+This example demonstrates a minimal anonymous chat application. The backend is a Java WebSocket server running on top of TCP. The frontend is a simple HTML page that uses WebSocket for real-time communication and supports sending text, images, audio, video and links.
+
+## Building and Running
+
+1. Ensure Java and Maven are installed on your system.
+2. Run `mvn package` to build a runnable jar with dependencies.
+3. Start the server:
+
+```bash
+java -jar target/server-1.0-SNAPSHOT-jar-with-dependencies.jar
+```
+
+The HTTP server will listen on port **8080** and the WebSocket server on port **8081**. Open `http://localhost:8080` in your browser to start chatting.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>anonymouschat</groupId>
+    <artifactId>server</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>ChatServer</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Anonymous Chat</title>
+<style>
+body { font-family: Arial, sans-serif; }
+#messages { border: 1px solid #ccc; height: 300px; overflow-y: scroll; }
+#messages img, #messages video, #messages audio { max-width: 200px; display: block; margin-top: 5px; }
+</style>
+</head>
+<body>
+<div id="messages"></div>
+<form id="form">
+<input type="text" id="text" placeholder="Say something" autocomplete="off" />
+<input type="file" id="file" />
+<select id="type">
+  <option value="text">text</option>
+  <option value="image">image</option>
+  <option value="audio">audio</option>
+  <option value="video">video</option>
+  <option value="link">link</option>
+</select>
+<button>Send</button>
+</form>
+<script>
+const ws = new WebSocket(`ws://${location.hostname}:8081`);
+const form = document.getElementById('form');
+const messages = document.getElementById('messages');
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  const div = document.createElement('div');
+  switch(msg.type){
+    case 'text':
+      div.textContent = msg.content;
+      break;
+    case 'image':
+      const img = new Image();
+      img.src = msg.content;
+      div.appendChild(img);
+      break;
+    case 'audio':
+      const audio = document.createElement('audio');
+      audio.controls = true;
+      audio.src = msg.content;
+      div.appendChild(audio);
+      break;
+    case 'video':
+      const video = document.createElement('video');
+      video.controls = true;
+      video.src = msg.content;
+      div.appendChild(video);
+      break;
+    case 'link':
+      const a = document.createElement('a');
+      a.href = msg.content;
+      a.textContent = msg.content;
+      a.target = '_blank';
+      div.appendChild(a);
+      break;
+  }
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+};
+form.onsubmit = async (e) => {
+  e.preventDefault();
+  const type = document.getElementById('type').value;
+  let content = document.getElementById('text').value;
+  const fileInput = document.getElementById('file');
+  if (fileInput.files[0]) {
+    content = await toDataURL(fileInput.files[0]);
+  }
+  ws.send(JSON.stringify({type, content}));
+  document.getElementById('text').value='';
+  fileInput.value='';
+};
+function toDataURL(file){
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.readAsDataURL(file);
+  });
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement ChatServer.java using Java WebSocket library and simple HTTP server
- update index.html to connect to Java WebSocket server
- document build instructions in README
- remove old Node server and config
- provide Maven build configuration

## Testing
- `javac ChatServer.java` *(fails: package org.java_websocket does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68411402e8408332ad2f1a026a8209e3